### PR TITLE
Update deps from dependency dashboard (#4)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,25 +35,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3.10.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4.2.0
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
@@ -71,7 +71,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6.19.2
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ kotlin = "2.4.10"
 ##  ⬆ = "2.4.20-Beta1"
 ##  ⬆ = "2.4.20-Beta2"
 
-hoplite="2.7.5"
+hoplite="2.9.0"
 
 kotlin-telegram="9.6.0"
 tinylog="2.7.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
     id("de.fayard.refreshVersions") version "0.60.6"
 }
 rootProject.name = "topics-bot"


### PR DESCRIPTION
Applies the pending updates listed in the Renovate Dependency Dashboard (#4).

## Gradle
- hoplite 2.7.5 → 2.9.0 (`hoplite-core` catalog version; `hoplite-toml` was already 2.9.0)
- foojay-resolver-convention 0.8.0 → 1.0.0

## CI actions (`.github/workflows/docker-publish.yml`)
- actions/checkout v4 → v7
- sigstore/cosign-installer v3.10.1 → v4.1.2
- docker/setup-buildx-action v3.12.0 → v4.2.0
- docker/login-action v3.3.0 → v4.6.0
- docker/metadata-action v5.10.0 → v6.2.0
- docker/build-push-action v6.19.2 → v7.3.0

## Verification
- `./gradlew build` passes (covers the hoplite + foojay bumps).
- CI-action bumps are **major versions**, not runtime-testable locally — the publish workflow validates them on push. Nothing else in the repo pins these actions.

## Not included (still open on the dashboard)
- foojay had v0.10.0 as an alternative to v1.0.0 — took v1.0.0.
- docker/login-action also offered v3.7.0 — took the v4.6.0 major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)